### PR TITLE
Support for static builds with musl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for usqlr - Server version of usql with MCP support
 
-.PHONY: build test test-sqlite test-drivers test-db clean help db-start db-stop db-test db-list
+.PHONY: build build-musl test test-sqlite test-drivers test-db clean help db-start db-stop db-test db-list
 
 # Binary names
 BINARY_NAME=usqlr
@@ -9,6 +9,7 @@ TESTS_DIR=tests
 
 # Go build flags
 LDFLAGS=-ldflags "-s -w"
+MUSL_LDFLAGS=-ldflags "-s -w -linkmode external -extldflags '-static'"
 
 # Default target
 all: build
@@ -17,6 +18,11 @@ all: build
 build:
 	@echo "Building usqlr..."
 	go build $(LDFLAGS) -o $(BINARY_NAME) ./cmd/usqlr
+
+# Build the usqlr binary with musl (static linking)
+build-musl:
+	@echo "Building usqlr with musl (static linking)..."
+	CC=musl-gcc CGO_ENABLED=1 go build $(MUSL_LDFLAGS) -o $(BINARY_NAME) ./cmd/usqlr
 
 # Run all tests
 test: build test-sqlite test-drivers
@@ -102,6 +108,7 @@ clean:
 help:
 	@echo "Available targets:"
 	@echo "  build        - Build the usqlr binary"
+	@echo "  build-musl   - Build the usqlr binary with musl (static linking)"
 	@echo "  test         - Run all tests"
 	@echo "  test-sqlite  - Run SQLite integration test"
 	@echo "  test-drivers - Run multi-database driver test"
@@ -118,6 +125,7 @@ help:
 	@echo ""
 	@echo "Examples:"
 	@echo "  make build"
+	@echo "  make build-musl"
 	@echo "  make test"
 	@echo "  make test-db DSN=\"sqlite3://test.db\""
 	@echo "  make db-start DB=postgres"


### PR DESCRIPTION
This pull request updates the `Makefile` to add support for building the `usqlr` binary with musl for static linking. The most important changes include the addition of a new `build-musl` target, updates to the linker flags, and corresponding updates to the `help` documentation.

### Enhancements to build process:
* Added a new `build-musl` target to build the `usqlr` binary with musl for static linking. This includes setting `CC=musl-gcc` and enabling `CGO` with appropriate linker flags. (`[MakefileR22-R26](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R22-R26)`)
* Introduced `MUSL_LDFLAGS` variable with linker flags for static linking using musl. (`[MakefileR12](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R12)`)

### Documentation updates:
* Updated `.PHONY` targets to include the new `build-musl` target. (`[MakefileL3-R3](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L3-R3)`)
* Added `build-musl` to the `help` section and examples to document its usage. (`[[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R111)`, `[[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R128)`)